### PR TITLE
Use WP-CLI nightly

### DIFF
--- a/wheezy/Dockerfile
+++ b/wheezy/Dockerfile
@@ -38,7 +38,7 @@ RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php5/ap
 #
 # Install WP-CLI
 #
-RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
+RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar \
     && chmod +x wp-cli.phar \
     && mv wp-cli.phar /usr/local/bin/wp
 


### PR DESCRIPTION
It's stable enough for local development, and is compatible with WordPress trunk.
