### PR TITLE
Update Debian9,php7,MariaDB and change WP-CLI installation.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 MAINTAINER ixkaito <ixkaito@gmail.com>
 
 RUN apt-get update \
@@ -8,14 +8,14 @@ RUN apt-get update \
     ca-certificates \
     curl \
     less \
-    libapache2-mod-php5 \
+    libapache2-mod-php \
     mysql-server \
     mysql-client \
-    php5 \
-    php5-cli \
-    php5-curl \
-    php5-gd \
-    php5-mysql \
+    php7.0 \
+    php7.0-cli \
+    php7.0-curl \
+    php7.0-gd \
+    php7.0-mysql \
     supervisor \
     vim \
   && rm -rf /var/lib/apt/lists/*
@@ -40,10 +40,10 @@ RUN adduser --uid 1000 --gecos '' --disabled-password wocker \
 #
 # php.ini settings
 #
-RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php5/apache2/php.ini \
-  && sed -i -e "s/^post_max_size.*/post_max_size = 64M/" /etc/php5/apache2/php.ini \
-  && sed -i -e "s/^display_errors.*/display_errors = On/" /etc/php5/apache2/php.ini \
-  && sed -i -e "s/^;mbstring.internal_encoding.*/mbstring.internal_encoding = UTF-8/" /etc/php5/apache2/php.ini
+RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php/7.0/apache2/php.ini \
+  && sed -i -e "s/^post_max_size.*/post_max_size = 64M/" /etc/php/7.0/apache2/php.ini \
+  && sed -i -e "s/^display_errors.*/display_errors = On/" /etc/php/7.0/apache2/php.ini \
+  && sed -i -e "s/^;mbstring.internal_encoding.*/mbstring.internal_encoding = UTF-8/" /etc/php/7.0/apache2/php.ini
 
 #
 # Install WP-CLI

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,9 @@ RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php5/ap
 #
 # Install WP-CLI
 #
-RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar \
-  && chmod +x wp-cli-nightly.phar \
-  && mv wp-cli-nightly.phar /usr/local/bin/wp
+RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
+  && chmod +x wp-cli.phar \
+  && mv wp-cli.phar /usr/local/bin/wp
 
 #
 # MySQL settings & Install WordPress

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,12 +53,12 @@ RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli
   && mv wp-cli.phar /usr/local/bin/wp
 
 #
-# MySQL settings & Install WordPress
+# MariaDB settings & Install WordPress
 #
 RUN mkdir -p /var/www/wordpress
 ADD wp-cli.yml /var/www
 WORKDIR /var/www/wordpress
-RUN sed -i -e "s/^bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/my.cnf \
+RUN sed -i -e "s/^bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/mariadb.conf.d/50-server.cnf  \
   && service mysql start \
   && mysqladmin -u root password root \
   && mysql -uroot -proot -e \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,12 +26,6 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 #
-# Install Mailcatcher
-#
-RUN gem install mailcatcher
-
-
-#
 # `mysqld_safe` patch
 # @see https://github.com/wckr/wocker/pull/28#issuecomment-195945765
 #
@@ -49,12 +43,18 @@ RUN adduser --uid 1000 --gecos '' --disabled-password wocker \
   && a2enmod rewrite
 
 #
+# Install Mailcatcher
+#
+RUN gem install mailcatcher
+
+#
 # php.ini settings
 #
 RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php/7.0/apache2/php.ini \
   && sed -i -e "s/^post_max_size.*/post_max_size = 64M/" /etc/php/7.0/apache2/php.ini \
   && sed -i -e "s/^display_errors.*/display_errors = On/" /etc/php/7.0/apache2/php.ini \
-  && sed -i -e "s/^;mbstring.internal_encoding.*/mbstring.internal_encoding = UTF-8/" /etc/php/7.0/apache2/php.ini
+  && sed -i -e "s/^;mbstring.internal_encoding.*/mbstring.internal_encoding = UTF-8/" /etc/php/7.0/apache2/php.ini \
+  && sed -i -e "s#^;sendmail_path.*#sendmail_path = /usr/local/bin/catchmail#" /etc/php/7.0/apache2/php.ini
 
 #
 # Xdebug settings

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,17 @@ RUN apt-get update \
     php7.0-xdebug \
     supervisor \
     vim \
+  && apt-get install -y build-essential software-properties-common \
+    ruby \
+    ruby-dev \
+    libsqlite3-dev \
   && rm -rf /var/lib/apt/lists/*
+
+#
+# Install Mailcatcher
+#
+RUN gem install mailcatcher
+
 
 #
 # `mysqld_safe` patch

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,13 @@ RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php5/ap
 ADD xdebug.ini /etc/php5/cli/conf.d/20-xdebug.ini
 
 #
+# Install PHPUnit
+#
+RUN curl -OL https://phar.phpunit.de/phpunit.phar \
+    && chmod +x phpunit.phar \
+    && mv phpunit.phar /usr/local/bin/phpunit
+
+#
 # Install WP-CLI
 #
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
 RUN sed -i -e 's/file) cmd="$cmd >> "`shell_quote_string "$err_log"`" 2>\&1" ;;/file) cmd="$cmd >> "`shell_quote_string "$err_log"`" 2>\&1 \& wait" ;;/' /usr/bin/mysqld_safe
 
 #
-# Apache Settings
+# Apache settings
 #
 RUN adduser --uid 1000 --gecos '' --disabled-password wocker \
   && echo "ServerName localhost" >> /etc/apache2/apache2.conf \
@@ -48,6 +48,11 @@ RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php5/ap
   && sed -i -e "s/^;mbstring.internal_encoding.*/mbstring.internal_encoding = UTF-8/" /etc/php5/apache2/php.ini
 
 #
+# Xdebug settings
+#
+ADD xdebug.ini /etc/php5/cli/conf.d/20-xdebug.ini
+
+#
 # Install WP-CLI
 #
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar \
@@ -55,7 +60,7 @@ RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli
   && mv wp-cli-nightly.phar /usr/local/bin/wp
 
 #
-# MySQL settings & Install WordPress
+# MySQL settings & install WordPress
 #
 RUN mkdir -p /var/www/wordpress
 ADD wp-cli.yml /var/www

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php/7.0
 #
 # Xdebug settings
 #
-ADD xdebug.ini /etc/php5/cli/conf.d/20-xdebug.ini
+ADD xdebug.ini /etc/php/7.0/cli/conf.d/20-xdebug.ini
 
 #
 # Install PHPUnit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,25 @@
 FROM debian:jessie
 MAINTAINER ixkaito <ixkaito@gmail.com>
 
+ENV TERM "xterm"
+
+ENV BUILDPCKGS "autoconf automake autopoint autotools-dev binutils bsdmainutils \
+  build-essential bzip2 cpp cpp-4.9 debhelper dh-php5 dpkg-dev fakeroot file \
+  g++ g++-4.9 gcc gcc-4.9 gettext gettext-base groff-base intltool-debian \
+  libalgorithm-diff-perl libalgorithm-diff-xs-perl libalgorithm-merge-perl \
+  libasan1 libasprintf-dev libasprintf0c2 libatomic1 libc-dev-bin libc6-dev \
+  libcilkrts5 libcloog-isl4 libcroco3 libdpkg-perl libfakeroot \
+  libfile-fcntllock-perl libgcc-4.9-dev libgettextpo-dev libgettextpo0 \
+  libglib2.0-0 libglib2.0-data libgomp1 libisl10 libitm1 liblsan0 \
+  libltdl-dev libltdl7 libmail-sendmail-perl libmpc3 libmpfr4 libpcre3-dev \
+  libpcrecpp0 libpipeline1 libquadmath0 libsigsegv2 libssl-dev libssl-doc \
+  libstdc++-4.9-dev libsys-hostname-long-perl libtimedate-perl libtool \
+  libtsan0 libubsan0 libunistring0 linux-libc-dev m4 make man-db manpages \
+  manpages-dev patch php-pear php5-dev pkg-php-tools po-debconf \
+  shared-mime-info shtool xdg-user-dirs xz-utils zlib1g-dev"
+
 RUN apt-get update \
+  && apt-get upgrade -y \
   && apt-get clean \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     apache2 \
@@ -9,48 +27,91 @@ RUN apt-get update \
     curl \
     less \
     libapache2-mod-php5 \
+    lsb-release \
     mysql-server \
     mysql-client \
+    nano \
     php5 \
     php5-cli \
     php5-curl \
+    php5-dev \
     php5-gd \
     php5-mysql \
+    php5-xdebug \
     supervisor \
     vim \
-  && rm -rf /var/lib/apt/lists/*
+  && touch /etc/php5/cli/conf.d/30-xdebug.ini \
+  && echo " \
+    zend_extension=/usr/lib/php5/20131226/xdebug.so \
+    xdebug.overload_var_dump = 1 \
+    xdebug.var_disply_max_depth = -1 \
+    xdebug.var_display_max_children = -1 \
+    xdebug.var_display_max_data = 512 \
+    xdebug.max_nesting_level = -1 \
+    xdebug.collect_params = 4 \
+    xdebug.profiler_enable_trigger = 1 \
+    xdebug.profiler_enable = 0 \
+    xdebug.remote_enable = 1 \
+    xdebug.profiler_output_dir = \"/tmp\" \
+    xdebug.profiler_output_name = \"cachegrind.out.%t-%s\"" \
+      > /etc/php5/cli/conf.d/30-xdebug.ini \
+  && apt-get remove ${BUILDPCKGS} \
+  && rm -rf \
+    /var/lib/apt/lists/* \
+    /usr/share/man \
+    /usr/games \
+    /tmp/* \
+    /var/tmp/*
 
 #
 # `mysqld_safe` patch
 # @see https://github.com/wckr/wocker/pull/28#issuecomment-195945765
 #
-RUN sed -i -e 's/file) cmd="$cmd >> "`shell_quote_string "$err_log"`" 2>\&1" ;;/file) cmd="$cmd >> "`shell_quote_string "$err_log"`" 2>\&1 \& wait" ;;/' /usr/bin/mysqld_safe
+RUN sed -i -e \
+  's/file) cmd="$cmd >> "`shell_quote_string "$err_log"`" 2>\&1" ;;/file) cmd="$cmd >> "`shell_quote_string "$err_log"`" 2>\&1 \& wait" ;;/' \
+  /usr/bin/mysqld_safe
 
 #
 # Apache Settings
 #
 RUN adduser --uid 1000 --gecos '' --disabled-password wocker \
-  && echo "ServerName localhost" >> /etc/apache2/apache2.conf \
-  && sed -i -e '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf \
-  && sed -i -e "s#DocumentRoot.*#DocumentRoot /var/www/wordpress#" /etc/apache2/sites-available/000-default.conf \
-  && sed -i -e "s/export APACHE_RUN_USER=.*/export APACHE_RUN_USER=wocker/" /etc/apache2/envvars \
-  && sed -i -e "s/export APACHE_RUN_GROUP=.*/export APACHE_RUN_GROUP=wocker/" /etc/apache2/envvars \
-  && a2enmod rewrite
+    && echo "ServerName localhost" >> /etc/apache2/apache2.conf \
+    && sed -i -e \
+        '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' \
+        /etc/apache2/apache2.conf \
+    && sed -i -e \
+        "s#DocumentRoot.*#DocumentRoot /var/www/wordpress#" \
+        /etc/apache2/sites-available/000-default.conf \
+    && sed -i -e \
+        "s/export APACHE_RUN_USER=.*/export APACHE_RUN_USER=wocker/" \
+        /etc/apache2/envvars \
+    && sed -i -e \
+        "s/export APACHE_RUN_GROUP=.*/export APACHE_RUN_GROUP=wocker/" \
+        /etc/apache2/envvars \
+    && a2enmod rewrite
 
 #
 # php.ini settings
 #
-RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php5/apache2/php.ini \
-  && sed -i -e "s/^post_max_size.*/post_max_size = 64M/" /etc/php5/apache2/php.ini \
-  && sed -i -e "s/^display_errors.*/display_errors = On/" /etc/php5/apache2/php.ini \
-  && sed -i -e "s/^;mbstring.internal_encoding.*/mbstring.internal_encoding = UTF-8/" /etc/php5/apache2/php.ini
+RUN sed -i -e \
+    "s/^upload_max_filesize.*/upload_max_filesize = 32M/" \
+    /etc/php5/apache2/php.ini \
+    && sed -i -e \
+        "s/^post_max_size.*/post_max_size = 64M/" \
+        /etc/php5/apache2/php.ini \
+    && sed -i -e \
+        "s/^display_errors.*/display_errors = On/" \
+        /etc/php5/apache2/php.ini \
+    && sed -i -e \
+        "s/^;mbstring.internal_encoding.*/mbstring.internal_encoding = UTF-8/" \
+        /etc/php5/apache2/php.ini
 
 #
 # Install WP-CLI
 #
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar \
-  && chmod +x wp-cli-nightly.phar \
-  && mv wp-cli-nightly.phar /usr/local/bin/wp
+    && chmod +x wp-cli-nightly.phar \
+    && mv wp-cli-nightly.phar /usr/local/bin/wp
 
 #
 # MySQL settings & Install WordPress
@@ -58,17 +119,19 @@ RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli
 RUN mkdir -p /var/www/wordpress
 ADD wp-cli.yml /var/www
 WORKDIR /var/www/wordpress
-RUN sed -i -e "s/^bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/my.cnf \
-  && service mysql start \
-  && mysqladmin -u root password root \
-  && mysql -uroot -proot -e \
-    "CREATE DATABASE wordpress DEFAULT CHARACTER SET utf8; grant all privileges on wordpress.* to wordpress@'%' identified by 'wordpress';" \
-  && wp core download --allow-root \
-  && wp core config --allow-root \
-    --dbname=wordpress \
-    --dbuser=wordpress \
-    --dbpass=wordpress \
-    --dbhost=localhost
+RUN sed -i -e \
+    "s/^bind-address.*/bind-address = 0.0.0.0/" \
+    /etc/mysql/my.cnf \
+    && service mysql start \
+    && mysqladmin -u root password root \
+    && mysql -uroot -proot -e \
+      "CREATE DATABASE wordpress DEFAULT CHARACTER SET utf8; grant all privileges on wordpress.* to wordpress@'%' identified by 'wordpress';" \
+    && wp core download --allow-root \
+    && wp core config --allow-root \
+      --dbname=wordpress \
+      --dbuser=wordpress \
+      --dbpass=wordpress \
+      --dbhost=localhost
 RUN chown -R wocker:wocker /var/www/wordpress
 
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,110 +1,119 @@
 FROM debian:jessie
-MAINTAINER ixkaito <ixkaito@gmail.com>
-
-ENV TERM "xterm"
-
-ENV BUILDPCKGS "autoconf automake autopoint autotools-dev binutils bsdmainutils \
-  build-essential bzip2 cpp cpp-4.9 debhelper dh-php5 dpkg-dev fakeroot file \
-  g++ g++-4.9 gcc gcc-4.9 gettext gettext-base groff-base intltool-debian \
-  libalgorithm-diff-perl libalgorithm-diff-xs-perl libalgorithm-merge-perl \
-  libasan1 libasprintf-dev libasprintf0c2 libatomic1 libc-dev-bin libc6-dev \
-  libcilkrts5 libcloog-isl4 libcroco3 libdpkg-perl libfakeroot \
-  libfile-fcntllock-perl libgcc-4.9-dev libgettextpo-dev libgettextpo0 \
-  libglib2.0-0 libglib2.0-data libgomp1 libisl10 libitm1 liblsan0 \
-  libltdl-dev libltdl7 libmail-sendmail-perl libmpc3 libmpfr4 libpcre3-dev \
-  libpcrecpp0 libpipeline1 libquadmath0 libsigsegv2 libssl-dev libssl-doc \
-  libstdc++-4.9-dev libsys-hostname-long-perl libtimedate-perl libtool \
-  libtsan0 libubsan0 libunistring0 linux-libc-dev m4 make man-db manpages \
-  manpages-dev patch php-pear php5-dev pkg-php-tools po-debconf \
-  shared-mime-info shtool xdg-user-dirs xz-utils zlib1g-dev"
+MAINTAINER not important
 
 RUN apt-get update \
-  && apt-get upgrade -y \
-  && apt-get clean \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    apache2 \
-    ca-certificates \
-    curl \
-    less \
-    libapache2-mod-php5 \
-    lsb-release \
-    mysql-server \
-    mysql-client \
-    nano \
-    php5 \
-    php5-cli \
-    php5-curl \
-    php5-dev \
-    php5-gd \
-    php5-mysql \
-    php5-xdebug \
-    supervisor \
-    vim \
-  && touch /etc/php5/cli/conf.d/30-xdebug.ini \
-  && echo " \
-    zend_extension=/usr/lib/php5/20131226/xdebug.so \
-    xdebug.overload_var_dump = 1 \
-    xdebug.var_disply_max_depth = -1 \
-    xdebug.var_display_max_children = -1 \
-    xdebug.var_display_max_data = 512 \
-    xdebug.max_nesting_level = -1 \
-    xdebug.collect_params = 4 \
-    xdebug.profiler_enable_trigger = 1 \
-    xdebug.profiler_enable = 0 \
-    xdebug.remote_enable = 1 \
-    xdebug.profiler_output_dir = \"/tmp\" \
-    xdebug.profiler_output_name = \"cachegrind.out.%t-%s\"" \
-      > /etc/php5/cli/conf.d/30-xdebug.ini \
-  && apt-get remove ${BUILDPCKGS} \
-  && rm -rf \
-    /var/lib/apt/lists/* \
-    /usr/share/man \
-    /usr/games \
-    /tmp/* \
-    /var/tmp/*
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      apache2 \
+      libapache2-mod-php5 \
+      php5 \
+      php5-cli \
+      php5-gd \
+      php5-mysql \
+      php5-curl \
+      php5-dev \
+      php5-xdebug \
+      mysql-server \
+      mysql-client \
+      curl \
+      supervisor \
+      ca-certificates \
+      vim \
+      less \
+      php5-dev \
+      libsqlite3-dev \
+      sqlite3 \
+      ruby \
+      ruby-dev \
+      phpmyadmin \
+      git \
+      sudo \
+      make \
+      g++ \
+      php-pear \
+
+      && rm -rf /var/lib/apt/lists/*
+
+#
+# Xdebug remote host setup
+#
+RUN echo "zend_extension=/usr/lib/php5/20131226/xdebug.so" >> /etc/php5/apache2/conf.d/20-xdebug.ini \
+    && echo "xdebug.remote_host=10.0.23.1" >> /etc/php5/apache2/conf.d/20-xdebug.ini \
+    && echo "xdebug.remote_port = 9000" >> /etc/php5/apache2/conf.d/20-xdebug.ini \
+    && echo "xdebug.remote_enable = 1" >> /etc/php5/apache2/conf.d/20-xdebug.ini \
+    && echo "xdebug.remote_autostart = 0" >> /etc/php5/apache2/conf.d/20-xdebug.ini \
+    && echo "xdebug.profiler_enable_trigger = 1" >> /etc/php5/apache2/conf.d/20-xdebug.ini \
+    && echo "xdebug.remote_handler = dbgp" >> /etc/php5/apache2/conf.d/20-xdebug.ini \
+    && echo "xdebug.profiler_enable=0" >> /etc/php5/apache2/conf.d/20-xdebug.ini \
+    && echo "xdebug.profiler_output_dir=/var/www/profiler" >> /etc/php5/apache2/conf.d/20-xdebug.ini \
+    && echo "xdebug.profiler_output_name = "cachegrind.out.%p"" >> /etc/php5/apache2/conf.d/20-xdebug.ini
+
+
+#
+# Install MailCatcher
+#
+RUN gem install mailcatcher
+
+#
+#Install Mailcatcher dependencies
+#
+RUN gem install coffee-script
+RUN gem install compass
+RUN gem install minitest
+RUN gem install rake
+RUN gem install rdoc
+RUN gem install sass
+RUN gem install selenium-webdriver
+RUN gem install sprockets
+RUN gem install sprockets-helpers
+RUN gem install sprockets-sass
+RUN gem install uglifier
+
+
+#
+# Setup MailCatcher Apache proxy-pass
+# This should be obsolete now - keeping it for the record only.
+#RUN sed -i -e '/<\/VirtualHost>/i \ProxyPass \/mailcatcher http:\/\/127.0.0.1:1080\/ \n' /etc/apache2/sites-enabled/000-default.conf
+#RUN sed -i -e '/<\/VirtualHost>/i \ProxyPass \/assets\/mailcatcher.css http:\/\/127.0.0.1:1080\/assets\/mailcatcher.css \n' /etc/apache2/sites-enabled/000-default.conf
+#RUN sed -i -e '/<\/VirtualHost>/i \ProxyPass \/assets\/mailcatcher.js http:\/\/127.0.0.1:1080\/assets\/mailcatcher.js \n' /etc/apache2/sites-enabled/000-default.conf
 
 #
 # `mysqld_safe` patch
 # @see https://github.com/wckr/wocker/pull/28#issuecomment-195945765
 #
-RUN sed -i -e \
-  's/file) cmd="$cmd >> "`shell_quote_string "$err_log"`" 2>\&1" ;;/file) cmd="$cmd >> "`shell_quote_string "$err_log"`" 2>\&1 \& wait" ;;/' \
-  /usr/bin/mysqld_safe
+RUN sed -i -e 's/file) cmd="$cmd >> "`shell_quote_string "$err_log"`" 2>\&1" ;;/file) cmd="$cmd >> "`shell_quote_string "$err_log"`" 2>\&1 \& wait" ;;/' /usr/bin/mysqld_safe
 
 #
 # Apache Settings
+# Enable required modules for rewrite, vhosts, and proxy (proxy required for mailcatcher)
 #
 RUN adduser --uid 1000 --gecos '' --disabled-password wocker \
     && echo "ServerName localhost" >> /etc/apache2/apache2.conf \
-    && sed -i -e \
-        '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' \
-        /etc/apache2/apache2.conf \
-    && sed -i -e \
-        "s#DocumentRoot.*#DocumentRoot /var/www/wordpress#" \
-        /etc/apache2/sites-available/000-default.conf \
-    && sed -i -e \
-        "s/export APACHE_RUN_USER=.*/export APACHE_RUN_USER=wocker/" \
-        /etc/apache2/envvars \
-    && sed -i -e \
-        "s/export APACHE_RUN_GROUP=.*/export APACHE_RUN_GROUP=wocker/" \
-        /etc/apache2/envvars \
-    && a2enmod rewrite
+    && sed -i -e '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf \
+    && sed -i -e "s#DocumentRoot.*#DocumentRoot \/var\/www\/wordpress#" /etc/apache2/sites-enabled/000-default.conf \
+    && sed -i -e "s/export APACHE_RUN_USER=.*/export APACHE_RUN_USER=wocker/" /etc/apache2/envvars \
+    && sed -i -e "s/export APACHE_RUN_GROUP=.*/export APACHE_RUN_GROUP=wocker/" /etc/apache2/envvars \
+    && a2enmod rewrite \
+    && a2enmod vhost_alias \
+    && a2enmod ssl
+#    && a2enmod proxy \
+#    && a2enmod proxy_http
+#   obsolete and not needed modules - see mailcatcher above.
 
 #
 # php.ini settings
+# Change sendmail path to allow the usage of mailcatcher
 #
-RUN sed -i -e \
-    "s/^upload_max_filesize.*/upload_max_filesize = 32M/" \
-    /etc/php5/apache2/php.ini \
-    && sed -i -e \
-        "s/^post_max_size.*/post_max_size = 64M/" \
-        /etc/php5/apache2/php.ini \
-    && sed -i -e \
-        "s/^display_errors.*/display_errors = On/" \
-        /etc/php5/apache2/php.ini \
-    && sed -i -e \
-        "s/^;mbstring.internal_encoding.*/mbstring.internal_encoding = UTF-8/" \
-        /etc/php5/apache2/php.ini
+RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 256M/" /etc/php5/apache2/php.ini \
+    && sed -i -e "s/^post_max_size.*/post_max_size = 267M/" /etc/php5/apache2/php.ini \
+    && sed -i -e "s/^display_errors.*/display_errors = On/" /etc/php5/apache2/php.ini \
+    && sed -i -e "s/^;mbstring.internal_encoding.*/mbstring.internal_encoding = UTF-8/" /etc/php5/apache2/php.ini \
+    && sed -i -e "s/^;sendmail_path.*/sendmail_path = \/usr\/bin\/env catchmail/" /etc/php5/apache2/php.ini
+#
+# phpmyadmin copy config to sites-enabled
+#
+RUN cp /etc/phpmyadmin/apache.conf /etc/apache2/sites-enabled/
 
 #
 # Install WP-CLI
@@ -117,11 +126,10 @@ RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli
 # MySQL settings & Install WordPress
 #
 RUN mkdir -p /var/www/wordpress
+RUN mkdir -p /var/www/profiler
 ADD wp-cli.yml /var/www
 WORKDIR /var/www/wordpress
-RUN sed -i -e \
-    "s/^bind-address.*/bind-address = 0.0.0.0/" \
-    /etc/mysql/my.cnf \
+RUN sed -i -e "s/^bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/my.cnf \
     && service mysql start \
     && mysqladmin -u root password root \
     && mysql -uroot -proot -e \
@@ -131,18 +139,64 @@ RUN sed -i -e \
       --dbname=wordpress \
       --dbuser=wordpress \
       --dbpass=wordpress \
-      --dbhost=localhost
+      --dbhost=localhost \
+    && wp core install --allow-root \
+      --admin_name=admin \
+      --admin_password=admin \
+      --admin_email=admin@debugger.dev \
+      --url=http://debugger.dev \
+      --title=WordPress \
+    && wp theme update --allow-root --all \
+    && wp plugin update --allow-root --all \
+    && wp menu create "Navigation" --allow-root \
+    && wp menu item add-custom navigation "Management Interface" "http://debugger.dev/interface.php" --allow-root \
+    && wp menu item add-custom navigation "MailCatcher" "http://debugger.dev:1080" --allow-root \
+    && wp menu item add-custom navigation "PhpMyAdmin" "http://debugger.dev/phpmyadmin/" --allow-root \
+    && wp menu item add-custom navigation "WebGrind" "http://debugger.dev/webgrind/" --allow-root \
+    && wp menu location assign Navigation primary --allow-root
+
+
+#Own directories and change permissions - this helps for the automatic scripts for Vhost creation
 RUN chown -R wocker:wocker /var/www/wordpress
+RUN chown -R wocker:wocker /var/www
+RUN chown -R wocker:wocker /etc/apache2/sites-enabled
+RUN chown -R wocker:wocker /etc/hosts
+RUN chown -R wocker:wocker /var/www/profiler
+RUN chmod 777 /etc/hosts
+RUN touch /etc/hosts2
+RUN chown -R wocker:wocker /etc/hosts2
+RUN chmod 777 /etc/hosts2
+RUN touch /etc/hosts3
+RUN chown -R wocker:wocker /etc/hosts3
+RUN chmod 777 /etc/hosts3
+RUN git clone https://github.com/jokkedk/webgrind.git
+#Add allowed command to the user Wocker, so that he can reload apache configuration without password via sudo
+RUN echo "Cmnd_Alias      RESTART_APACHE = /usr/sbin/service apache2 force-reload" >> /etc/sudoers
+RUN echo "Cmnd_Alias      UPDATE_HOSTS = /bin/cp -f /etc/hosts2 /etc/hosts"  >> /etc/sudoers
+RUN echo "wocker ALL=NOPASSWD: RESTART_APACHE, UPDATE_HOSTS, /usr/local/bin/vhost, /usr/local/bin/wp-install, /bin/echo, /bin/sed" >> /etc/sudoers
 
 #
 # Open ports
 #
-EXPOSE 80 3306
+EXPOSE 80 443 3306 1080 9000
 
 #
 # Supervisor
 #
 RUN mkdir -p /var/log/supervisor
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+ADD restore_hosts /usr/local/bin/restore_hosts
+ADD vhost /usr/local/bin/vhost
+ADD wp-install /usr/local/bin/wp-install
+#Add Web interface and backend for adding WordPress installs + Vhosts
+ADD interface.php /var/www/wordpress/interface.php
+RUN chmod +x /usr/local/bin/vhost
+RUN chmod +x /usr/local/bin/wp-install
+RUN chmod +x /usr/local/bin/restore_hosts
+
+#Install composer - everybody needs that
+RUN curl -sS https://getcomposer.org/installer | php \
+    && mv composer.phar /usr/local/bin/composer \
+    && chmod +x /usr/local/bin/composer
 
 CMD ["/usr/bin/supervisord"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,10 @@ RUN apt-get update \
     php5 \
     php5-cli \
     php5-curl \
+    php5-dev \
     php5-gd \
     php5-mysql \
+    php5-xdebug \
     supervisor \
     vim \
   && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,82 +1,24 @@
 FROM debian:jessie
-MAINTAINER not important
+MAINTAINER ixkaito <ixkaito@gmail.com>
 
 RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get clean \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      apache2 \
-      libapache2-mod-php5 \
-      php5 \
-      php5-cli \
-      php5-gd \
-      php5-mysql \
-      php5-curl \
-      php5-dev \
-      php5-xdebug \
-      mysql-server \
-      mysql-client \
-      curl \
-      supervisor \
-      ca-certificates \
-      vim \
-      less \
-      php5-dev \
-      libsqlite3-dev \
-      sqlite3 \
-      ruby \
-      ruby-dev \
-      phpmyadmin \
-      git \
-      sudo \
-      make \
-      g++ \
-      php-pear \
-
-      && rm -rf /var/lib/apt/lists/*
-
-#
-# Xdebug remote host setup
-#
-RUN echo "zend_extension=/usr/lib/php5/20131226/xdebug.so" >> /etc/php5/apache2/conf.d/20-xdebug.ini \
-    && echo "xdebug.remote_host=10.0.23.1" >> /etc/php5/apache2/conf.d/20-xdebug.ini \
-    && echo "xdebug.remote_port = 9000" >> /etc/php5/apache2/conf.d/20-xdebug.ini \
-    && echo "xdebug.remote_enable = 1" >> /etc/php5/apache2/conf.d/20-xdebug.ini \
-    && echo "xdebug.remote_autostart = 0" >> /etc/php5/apache2/conf.d/20-xdebug.ini \
-    && echo "xdebug.profiler_enable_trigger = 1" >> /etc/php5/apache2/conf.d/20-xdebug.ini \
-    && echo "xdebug.remote_handler = dbgp" >> /etc/php5/apache2/conf.d/20-xdebug.ini \
-    && echo "xdebug.profiler_enable=0" >> /etc/php5/apache2/conf.d/20-xdebug.ini \
-    && echo "xdebug.profiler_output_dir=/var/www/profiler" >> /etc/php5/apache2/conf.d/20-xdebug.ini \
-    && echo "xdebug.profiler_output_name = "cachegrind.out.%p"" >> /etc/php5/apache2/conf.d/20-xdebug.ini
-
-
-#
-# Install MailCatcher
-#
-RUN gem install mailcatcher
-
-#
-#Install Mailcatcher dependencies
-#
-RUN gem install coffee-script
-RUN gem install compass
-RUN gem install minitest
-RUN gem install rake
-RUN gem install rdoc
-RUN gem install sass
-RUN gem install selenium-webdriver
-RUN gem install sprockets
-RUN gem install sprockets-helpers
-RUN gem install sprockets-sass
-RUN gem install uglifier
-
-
-#
-# Setup MailCatcher Apache proxy-pass
-# This should be obsolete now - keeping it for the record only.
-#RUN sed -i -e '/<\/VirtualHost>/i \ProxyPass \/mailcatcher http:\/\/127.0.0.1:1080\/ \n' /etc/apache2/sites-enabled/000-default.conf
-#RUN sed -i -e '/<\/VirtualHost>/i \ProxyPass \/assets\/mailcatcher.css http:\/\/127.0.0.1:1080\/assets\/mailcatcher.css \n' /etc/apache2/sites-enabled/000-default.conf
-#RUN sed -i -e '/<\/VirtualHost>/i \ProxyPass \/assets\/mailcatcher.js http:\/\/127.0.0.1:1080\/assets\/mailcatcher.js \n' /etc/apache2/sites-enabled/000-default.conf
+  && apt-get clean \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    apache2 \
+    ca-certificates \
+    curl \
+    less \
+    libapache2-mod-php5 \
+    mysql-server \
+    mysql-client \
+    php5 \
+    php5-cli \
+    php5-curl \
+    php5-gd \
+    php5-mysql \
+    supervisor \
+    vim \
+  && rm -rf /var/lib/apt/lists/*
 
 #
 # `mysqld_safe` patch
@@ -86,117 +28,58 @@ RUN sed -i -e 's/file) cmd="$cmd >> "`shell_quote_string "$err_log"`" 2>\&1" ;;/
 
 #
 # Apache Settings
-# Enable required modules for rewrite, vhosts, and proxy (proxy required for mailcatcher)
 #
 RUN adduser --uid 1000 --gecos '' --disabled-password wocker \
-    && echo "ServerName localhost" >> /etc/apache2/apache2.conf \
-    && sed -i -e '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf \
-    && sed -i -e "s#DocumentRoot.*#DocumentRoot \/var\/www\/wordpress#" /etc/apache2/sites-enabled/000-default.conf \
-    && sed -i -e "s/export APACHE_RUN_USER=.*/export APACHE_RUN_USER=wocker/" /etc/apache2/envvars \
-    && sed -i -e "s/export APACHE_RUN_GROUP=.*/export APACHE_RUN_GROUP=wocker/" /etc/apache2/envvars \
-    && a2enmod rewrite \
-    && a2enmod vhost_alias \
-    && a2enmod ssl
-#    && a2enmod proxy \
-#    && a2enmod proxy_http
-#   obsolete and not needed modules - see mailcatcher above.
+  && echo "ServerName localhost" >> /etc/apache2/apache2.conf \
+  && sed -i -e '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf \
+  && sed -i -e "s#DocumentRoot.*#DocumentRoot /var/www/wordpress#" /etc/apache2/sites-available/000-default.conf \
+  && sed -i -e "s/export APACHE_RUN_USER=.*/export APACHE_RUN_USER=wocker/" /etc/apache2/envvars \
+  && sed -i -e "s/export APACHE_RUN_GROUP=.*/export APACHE_RUN_GROUP=wocker/" /etc/apache2/envvars \
+  && a2enmod rewrite
 
 #
 # php.ini settings
-# Change sendmail path to allow the usage of mailcatcher
 #
-RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 256M/" /etc/php5/apache2/php.ini \
-    && sed -i -e "s/^post_max_size.*/post_max_size = 267M/" /etc/php5/apache2/php.ini \
-    && sed -i -e "s/^display_errors.*/display_errors = On/" /etc/php5/apache2/php.ini \
-    && sed -i -e "s/^;mbstring.internal_encoding.*/mbstring.internal_encoding = UTF-8/" /etc/php5/apache2/php.ini \
-    && sed -i -e "s/^;sendmail_path.*/sendmail_path = \/usr\/bin\/env catchmail/" /etc/php5/apache2/php.ini
-#
-# phpmyadmin copy config to sites-enabled
-#
-RUN cp /etc/phpmyadmin/apache.conf /etc/apache2/sites-enabled/
+RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php5/apache2/php.ini \
+  && sed -i -e "s/^post_max_size.*/post_max_size = 64M/" /etc/php5/apache2/php.ini \
+  && sed -i -e "s/^display_errors.*/display_errors = On/" /etc/php5/apache2/php.ini \
+  && sed -i -e "s/^;mbstring.internal_encoding.*/mbstring.internal_encoding = UTF-8/" /etc/php5/apache2/php.ini
 
 #
 # Install WP-CLI
 #
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar \
-    && chmod +x wp-cli-nightly.phar \
-    && mv wp-cli-nightly.phar /usr/local/bin/wp
+  && chmod +x wp-cli-nightly.phar \
+  && mv wp-cli-nightly.phar /usr/local/bin/wp
 
 #
 # MySQL settings & Install WordPress
 #
 RUN mkdir -p /var/www/wordpress
-RUN mkdir -p /var/www/profiler
 ADD wp-cli.yml /var/www
 WORKDIR /var/www/wordpress
 RUN sed -i -e "s/^bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/my.cnf \
-    && service mysql start \
-    && mysqladmin -u root password root \
-    && mysql -uroot -proot -e \
-      "CREATE DATABASE wordpress DEFAULT CHARACTER SET utf8; grant all privileges on wordpress.* to wordpress@'%' identified by 'wordpress';" \
-    && wp core download --allow-root \
-    && wp core config --allow-root \
-      --dbname=wordpress \
-      --dbuser=wordpress \
-      --dbpass=wordpress \
-      --dbhost=localhost \
-    && wp core install --allow-root \
-      --admin_name=admin \
-      --admin_password=admin \
-      --admin_email=admin@debugger.dev \
-      --url=http://debugger.dev \
-      --title=WordPress \
-    && wp theme update --allow-root --all \
-    && wp plugin update --allow-root --all \
-    && wp menu create "Navigation" --allow-root \
-    && wp menu item add-custom navigation "Management Interface" "http://debugger.dev/interface.php" --allow-root \
-    && wp menu item add-custom navigation "MailCatcher" "http://debugger.dev:1080" --allow-root \
-    && wp menu item add-custom navigation "PhpMyAdmin" "http://debugger.dev/phpmyadmin/" --allow-root \
-    && wp menu item add-custom navigation "WebGrind" "http://debugger.dev/webgrind/" --allow-root \
-    && wp menu location assign Navigation primary --allow-root
-
-
-#Own directories and change permissions - this helps for the automatic scripts for Vhost creation
+  && service mysql start \
+  && mysqladmin -u root password root \
+  && mysql -uroot -proot -e \
+    "CREATE DATABASE wordpress DEFAULT CHARACTER SET utf8; grant all privileges on wordpress.* to wordpress@'%' identified by 'wordpress';" \
+  && wp core download --allow-root \
+  && wp core config --allow-root \
+    --dbname=wordpress \
+    --dbuser=wordpress \
+    --dbpass=wordpress \
+    --dbhost=localhost
 RUN chown -R wocker:wocker /var/www/wordpress
-RUN chown -R wocker:wocker /var/www
-RUN chown -R wocker:wocker /etc/apache2/sites-enabled
-RUN chown -R wocker:wocker /etc/hosts
-RUN chown -R wocker:wocker /var/www/profiler
-RUN chmod 777 /etc/hosts
-RUN touch /etc/hosts2
-RUN chown -R wocker:wocker /etc/hosts2
-RUN chmod 777 /etc/hosts2
-RUN touch /etc/hosts3
-RUN chown -R wocker:wocker /etc/hosts3
-RUN chmod 777 /etc/hosts3
-RUN git clone https://github.com/jokkedk/webgrind.git
-#Add allowed command to the user Wocker, so that he can reload apache configuration without password via sudo
-RUN echo "Cmnd_Alias      RESTART_APACHE = /usr/sbin/service apache2 force-reload" >> /etc/sudoers
-RUN echo "Cmnd_Alias      UPDATE_HOSTS = /bin/cp -f /etc/hosts2 /etc/hosts"  >> /etc/sudoers
-RUN echo "wocker ALL=NOPASSWD: RESTART_APACHE, UPDATE_HOSTS, /usr/local/bin/vhost, /usr/local/bin/wp-install, /bin/echo, /bin/sed" >> /etc/sudoers
 
 #
 # Open ports
 #
-EXPOSE 80 443 3306 1080 9000
+EXPOSE 80 3306
 
 #
 # Supervisor
 #
 RUN mkdir -p /var/log/supervisor
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-ADD restore_hosts /usr/local/bin/restore_hosts
-ADD vhost /usr/local/bin/vhost
-ADD wp-install /usr/local/bin/wp-install
-#Add Web interface and backend for adding WordPress installs + Vhosts
-ADD interface.php /var/www/wordpress/interface.php
-RUN chmod +x /usr/local/bin/vhost
-RUN chmod +x /usr/local/bin/wp-install
-RUN chmod +x /usr/local/bin/restore_hosts
-
-#Install composer - everybody needs that
-RUN curl -sS https://getcomposer.org/installer | php \
-    && mv composer.phar /usr/local/bin/composer \
-    && chmod +x /usr/local/bin/composer
 
 CMD ["/usr/bin/supervisord"]

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -17,3 +17,6 @@ command=/bin/bash -c "source /etc/apache2/envvars && exec /usr/sbin/apache2 -DFO
 
 [program:mysql]
 command=/usr/bin/mysqld_safe
+
+[program:mailcatcher]
+command=/usr/local/bin/mailcatcher --http-ip 0.0.0.0

--- a/xdebug.ini
+++ b/xdebug.ini
@@ -1,0 +1,5 @@
+zend_extension=xdebug.so
+xdebug.remote_enable=1
+xdebug.remote_connect_back=1
+xdebug.remote_port=9000
+xdebug.profiler_enable=0


### PR DESCRIPTION
Update php7 and Debian9, because Debian9 has not php5 package.
And Debian9 default mysql-server is MariaDB, so update MariaDB settings.
Change WP-CLI installation to official recommended ,WP-CLI nightly version can not install WordPress 4.8.2.