### PR TITLE
Change mailhog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,13 +59,14 @@ RUN sed -i -e "s/^user =.*/user = wocker/" /etc/php/7.0/fpm/pool.d/www.conf \
   && sed -i -e "s/^listen.group =.*/listen.group = wocker/" /etc/php/7.0/fpm/pool.d/www.conf
 
 #
-# php.ini settings
+# php.ini settings and php-fpm service start
 #
 RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php/7.0/fpm/php.ini \
   && sed -i -e "s/^post_max_size.*/post_max_size = 64M/" /etc/php/7.0/fpm/php.ini \
   && sed -i -e "s/^display_errors.*/display_errors = On/" /etc/php/7.0/fpm/php.ini \
   && sed -i -e "s/^;mbstring.internal_encoding.*/mbstring.internal_encoding = UTF-8/" /etc/php/7.0/fpm/php.ini \
   && sed -i -e "s#^;sendmail_path.*#sendmail_path = /usr/local/bin/catchmail#" /etc/php/7.0/fpm/php.ini
+RUN service php7.0-fpm start
 
 #
 # Xdebug settings

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,11 @@ RUN apt-get update \
     php7.0 \
     php7.0-cli \
     php7.0-curl \
+    php7.0-fpm \
     php7.0-gd \
+    php7.0-mbstring \
     php7.0-mysql \
     php7.0-xdebug \
-    php7.0-fpm \
     ruby \
     ruby-dev \
     software-properties-common \
@@ -64,8 +65,8 @@ RUN sed -i -e "s/^user =.*/user = wocker/" /etc/php/7.0/fpm/pool.d/www.conf \
 RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php/7.0/fpm/php.ini \
   && sed -i -e "s/^post_max_size.*/post_max_size = 64M/" /etc/php/7.0/fpm/php.ini \
   && sed -i -e "s/^display_errors.*/display_errors = On/" /etc/php/7.0/fpm/php.ini \
-  && sed -i -e "s/^;mbstring.internal_encoding.*/mbstring.internal_encoding = UTF-8/" /etc/php/7.0/fpm/php.ini \
-  && sed -i -e "s#^;sendmail_path.*#sendmail_path = /usr/local/bin/catchmail#" /etc/php/7.0/fpm/php.ini
+  && sed -i -e "s#^;sendmail_path.*#sendmail_path = /usr/local/bin/catchmail#" /etc/php/7.0/fpm/php.ini \
+  && sed -i -e "s/^;mbstring.func_overload.*/mbstring.func_overload = 1/" /etc/php/7.0/fpm/php.ini
 RUN service php7.0-fpm start
 
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,14 @@ RUN apt-get update \
 #
 # Install Gems
 #
-RUN gem install mailcatcher
 RUN gem install wordmove -v 2.0.0
+
+#
+# Install Mailhog
+#
+WORKDIR /usr/local/bin
+RUN curl -o mailhog -L https://github.com/mailhog/MailHog/releases/download/v1.0.0/MailHog_linux_amd64 \
+  && chmod +x mailhog
 
 #
 # `mysqld_safe` patch
@@ -65,7 +71,7 @@ RUN sed -i -e "s/^user =.*/user = wocker/" /etc/php/7.0/fpm/pool.d/www.conf \
 RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php/7.0/fpm/php.ini \
   && sed -i -e "s/^post_max_size.*/post_max_size = 64M/" /etc/php/7.0/fpm/php.ini \
   && sed -i -e "s/^display_errors.*/display_errors = On/" /etc/php/7.0/fpm/php.ini \
-  && sed -i -e "s#^;sendmail_path.*#sendmail_path = /usr/local/bin/mailcatcher#" /etc/php/7.0/fpm/php.ini
+  && sed -i -e "s#^;sendmail_path.*#sendmail_path = /usr/local/bin/mailhog sendmail#" /etc/php/7.0/fpm/php.ini
 RUN service php7.0-fpm start
 
 #
@@ -110,8 +116,7 @@ RUN chown -R wocker:wocker /var/www/wordpress
 #
 # Open ports
 #
-EXPOSE 80 3306
-EXPOSE 80 3306 1080
+EXPOSE 80 3306 8025
 
 #
 # Supervisor

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,13 +58,14 @@ RUN sed -i -e "s/^user =.*/user = wocker/" /etc/php/7.0/fpm/pool.d/www.conf \
   && sed -i -e "s/^listen.group =.*/listen.group = wocker/" /etc/php/7.0/fpm/pool.d/www.conf
 
 #
-# php.ini settings
+# php.ini settings and php-fpm service start
 #
 RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php/7.0/fpm/php.ini \
   && sed -i -e "s/^post_max_size.*/post_max_size = 64M/" /etc/php/7.0/fpm/php.ini \
   && sed -i -e "s/^display_errors.*/display_errors = On/" /etc/php/7.0/fpm/php.ini \
   && sed -i -e "s/^;mbstring.internal_encoding.*/mbstring.internal_encoding = UTF-8/" /etc/php/7.0/fpm/php.ini \
   && sed -i -e "s#^;sendmail_path.*#sendmail_path = /usr/local/bin/catchmail#" /etc/php/7.0/fpm/php.ini
+RUN service php7.0-fpm start
 
 #
 # Xdebug settings

--- a/Dockerfile
+++ b/Dockerfile
@@ -111,6 +111,7 @@ RUN chown -R wocker:wocker /var/www/wordpress
 # Open ports
 #
 EXPOSE 80 3306
+EXPOSE 80 3306 1080
 
 #
 # Supervisor

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,14 @@ MAINTAINER ixkaito <ixkaito@gmail.com>
 RUN apt-get update \
   && apt-get clean \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    apache2 \
     build-essential \
     ca-certificates \
     curl \
     less \
-    libapache2-mod-php \
     libsqlite3-dev \
     mysql-server \
     mysql-client \
+    nginx \
     openssh-client \
     php7.0 \
     php7.0-cli \
@@ -20,6 +19,7 @@ RUN apt-get update \
     php7.0-gd \
     php7.0-mysql \
     php7.0-xdebug \
+    php7.0-fpm \
     ruby \
     ruby-dev \
     software-properties-common \
@@ -28,36 +28,44 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 #
-# `mysqld_safe` patch
-# @see https://github.com/wckr/wocker/pull/28#issuecomment-195945765
-#
-RUN sed -i -e 's/file) cmd="$cmd >> "`shell_quote_string "$err_log"`" 2>\&1" ;;/file) cmd="$cmd >> "`shell_quote_string "$err_log"`" 2>\&1 \& wait" ;;/' /usr/bin/mysqld_safe
-
-#
-# Apache settings
-#
-RUN adduser --uid 1000 --gecos '' --disabled-password wocker \
-  && echo "ServerName localhost" >> /etc/apache2/apache2.conf \
-  && sed -i -e '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf \
-  && sed -i -e "s#DocumentRoot.*#DocumentRoot /var/www/wordpress#" /etc/apache2/sites-available/000-default.conf \
-  && sed -i -e "s/export APACHE_RUN_USER=.*/export APACHE_RUN_USER=wocker/" /etc/apache2/envvars \
-  && sed -i -e "s/export APACHE_RUN_GROUP=.*/export APACHE_RUN_GROUP=wocker/" /etc/apache2/envvars \
-  && a2enmod rewrite
-
-#
 # Install Gems
 #
 RUN gem install mailcatcher
 RUN gem install wordmove -v 2.0.0
 
 #
+# `mysqld_safe` patch
+# @see https://github.com/wckr/wocker/pull/28#issuecomment-195945765
+#
+RUN sed -i -e 's/file) cmd="$cmd >> "`shell_quote_string "$err_log"`" 2>\&1" ;;/file) cmd="$cmd >> "`shell_quote_string "$err_log"`" 2>\&1 \& wait" ;;/' /usr/bin/mysqld_safe
+
+#
+# nginx settings
+#
+RUN adduser --uid 1000 --gecos '' --disabled-password wocker
+RUN sed -i -e "s#root /var/www/html;#root /var/www/wordpress/;#" /etc/nginx/sites-available/default \
+  && sed -i -e "s/index index.html/index index.php index.html/" /etc/nginx/sites-available/default \
+  && sed -i -e "/location.*php/,/}/ s/#//" /etc/nginx/sites-available/default \
+  && sed -i -e "/# With php-cgi.*/,/}/ s/fastcgi.*//" /etc/nginx/sites-available/default \
+  && sed -i -e "s/server_name _;/server_name localhost;/" /etc/nginx/sites-available/default \
+  && sed -i -e "s/user www-data/user wocker/" /etc/nginx/nginx.conf
+
+#
+# php-fpm settings
+#
+RUN sed -i -e "s/^user =.*/user = wocker/" /etc/php/7.0/fpm/pool.d/www.conf \
+  && sed -i -e "s/^group = .*/group = wocker/" /etc/php/7.0/fpm/pool.d/www.conf \
+  && sed -i -e "s/^listen.owner =.*/listen.owner = wocker/" /etc/php/7.0/fpm/pool.d/www.conf \
+  && sed -i -e "s/^listen.group =.*/listen.group = wocker/" /etc/php/7.0/fpm/pool.d/www.conf
+
+#
 # php.ini settings
 #
-RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php/7.0/apache2/php.ini \
-  && sed -i -e "s/^post_max_size.*/post_max_size = 64M/" /etc/php/7.0/apache2/php.ini \
-  && sed -i -e "s/^display_errors.*/display_errors = On/" /etc/php/7.0/apache2/php.ini \
-  && sed -i -e "s/^;mbstring.internal_encoding.*/mbstring.internal_encoding = UTF-8/" /etc/php/7.0/apache2/php.ini \
-  && sed -i -e "s#^;sendmail_path.*#sendmail_path = /usr/local/bin/catchmail#" /etc/php/7.0/apache2/php.ini
+RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php/7.0/fpm/php.ini \
+  && sed -i -e "s/^post_max_size.*/post_max_size = 64M/" /etc/php/7.0/fpm/php.ini \
+  && sed -i -e "s/^display_errors.*/display_errors = On/" /etc/php/7.0/fpm/php.ini \
+  && sed -i -e "s/^;mbstring.internal_encoding.*/mbstring.internal_encoding = UTF-8/" /etc/php/7.0/fpm/php.ini \
+  && sed -i -e "s#^;sendmail_path.*#sendmail_path = /usr/local/bin/catchmail#" /etc/php/7.0/fpm/php.ini
 
 #
 # Xdebug settings
@@ -85,7 +93,7 @@ RUN mkdir -p /var/www/wordpress
 ADD wp-cli.yml /var/www
 ADD Movefile /var/www/wordpress
 WORKDIR /var/www/wordpress
-RUN sed -i -e "s/^bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/mariadb.conf.d/50-server.cnf  \
+RUN sed -i -e "s/^bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/mariadb.conf.d/50-server.cnf \
   && service mysql start \
   && mysqladmin -u root password root \
   && mysql -uroot -proot -e \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,9 @@ MAINTAINER ixkaito <ixkaito@gmail.com>
 RUN apt-get update \
   && apt-get clean \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    build-essential \
     ca-certificates \
     curl \
     less \
-    libsqlite3-dev \
     mysql-server \
     mysql-client \
     nginx \
@@ -18,12 +16,9 @@ RUN apt-get update \
     php7.0-curl \
     php7.0-fpm \
     php7.0-gd \
-    php7.0-mbstring \
     php7.0-mysql \
     php7.0-xdebug \
     ruby \
-    ruby-dev \
-    software-properties-common \
     supervisor \
     vim \
   && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,8 +65,7 @@ RUN sed -i -e "s/^user =.*/user = wocker/" /etc/php/7.0/fpm/pool.d/www.conf \
 RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php/7.0/fpm/php.ini \
   && sed -i -e "s/^post_max_size.*/post_max_size = 64M/" /etc/php/7.0/fpm/php.ini \
   && sed -i -e "s/^display_errors.*/display_errors = On/" /etc/php/7.0/fpm/php.ini \
-  && sed -i -e "s#^;sendmail_path.*#sendmail_path = /usr/local/bin/catchmail#" /etc/php/7.0/fpm/php.ini \
-  && sed -i -e "s/^;mbstring.func_overload.*/mbstring.func_overload = 1/" /etc/php/7.0/fpm/php.ini
+  && sed -i -e "s#^;sendmail_path.*#sendmail_path = /usr/local/bin/mailcatcher#" /etc/php/7.0/fpm/php.ini
 RUN service php7.0-fpm start
 
 #

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -10,13 +10,16 @@ minfds=1024
 minprocs=200
 
 [supervisorctl]
-serverurl=unix:///var/tmp/supervisor.sock
-
-[program:apache2]
-command=/bin/bash -c "source /etc/apache2/envvars && exec /usr/sbin/apache2 -DFOREGROUND"
+serverurl=unix://var/tmp/supervisor.sock
 
 [program:mysql]
 command=/usr/bin/mysqld_safe
 
 [program:mailcatcher]
 command=/usr/local/bin/mailcatcher --http-ip 0.0.0.0
+
+[program:nginx]
+command=/usr/sbin/nginx
+
+[program:php-fpm]
+command=php-fpm7.0

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -15,8 +15,8 @@ serverurl=unix://var/tmp/supervisor.sock
 [program:mysql]
 command=/usr/bin/mysqld_safe
 
-[program:mailcatcher]
-command=/usr/local/bin/mailcatcher --http-ip 0.0.0.0
+[program:mailhog]
+command=/usr/local/bin/mailhog
 
 [program:nginx]
 command=/usr/sbin/nginx


### PR DESCRIPTION
Change mail capture tool MailCatcher to mailhog.
Because WordPress can not send multibyte characters mail via MailCatcher smtp clone.
And remove build package, reduce image size.